### PR TITLE
feat: friendly operation IDs in OpenAPI spec

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,11 +15,14 @@ jobs:
         id: semver
         uses: ietf-tools/semver-action@v1
         with:
+          noVersionBumpBehaviour: current
+          noNewCommitBehaviour: current
           token: ${{ github.token }}
           branch: main
 
       - name: Create Release
         uses: ncipollo/release-action@v1.12.0
+        if: steps.semver.current != steps.semver.next
         with:
           allowUpdates: true
           draft: false
@@ -32,6 +35,7 @@ jobs:
       - name: Check for API changes
         uses: dorny/paths-filter@v2
         id: changes
+        if: steps.semver.current != steps.semver.next
         with:
           filters: |
             api:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -42,8 +42,8 @@ jobs:
       # and running the workflow steps. These should match the versions in the
       # devcontainer Dockerfile.
       matrix:
-        otp: ['26.0.2']       # Define the OTP version [required]
-        elixir: ['1.15.4']    # Define the elixir version [required]
+        otp: ['26.2.5']       # Define the OTP version [required]
+        elixir: ['1.16.3']    # Define the elixir version [required]
     steps:
     # Step: Setup Elixir + Erlang image as the base.
     - name: Set up Elixir

--- a/lib/bathlarp_web/controllers/v1/account_confirmation_controller.ex
+++ b/lib/bathlarp_web/controllers/v1/account_confirmation_controller.ex
@@ -21,6 +21,7 @@ defmodule BathLARPWeb.V1.AccountConfirmationController do
   tags ["accounts"]
 
   operation :create,
+    operation_id: "createAccountConfirmation",
     summary: "Create account confirmation",
     description:
       "Confirm that the e-mail address associated with a previously-created account has received a confirmation code.",

--- a/lib/bathlarp_web/controllers/v1/account_controller.ex
+++ b/lib/bathlarp_web/controllers/v1/account_controller.ex
@@ -20,6 +20,7 @@ defmodule BathLARPWeb.V1.AccountController do
   tags ["accounts"]
 
   operation :create,
+    operation_id: "createAccount",
     summary: "Create account",
     description:
       "Create an account. Completing registration will require additional steps, detailed in the response.",

--- a/lib/bathlarp_web/controllers/v1/pronouns_controller.ex
+++ b/lib/bathlarp_web/controllers/v1/pronouns_controller.ex
@@ -12,6 +12,7 @@ defmodule BathLARPWeb.V1.PronounsController do
   tags ["pronouns"]
 
   operation :index,
+    operation_id: "listPronouns",
     summary: "List pronouns",
     description: "List the pronoun sets currently supported by the BathLARP site.",
     responses: %{

--- a/lib/bathlarp_web/controllers/v1/session_controller.ex
+++ b/lib/bathlarp_web/controllers/v1/session_controller.ex
@@ -20,6 +20,7 @@ defmodule BathLARPWeb.V1.SessionController do
   tags ["sessions"]
 
   operation :create,
+    operation_id: "createSession",
     summary: "Create session",
     description: "Create a session on the BathLARP API server and obtain access tokens.",
     request_body: {"Session parameters", "application/vnd.api+json", CreateSessionRequest},
@@ -46,6 +47,7 @@ defmodule BathLARPWeb.V1.SessionController do
   end
 
   operation :update,
+    operation_id: "updateSession",
     summary: "Update session",
     description: "Refresh a session on the BathLARP API and obtain fresh access tokens.",
     request_body: {"Session parameters", "application/vnd.api+json", UpdateSessionRequest},
@@ -70,6 +72,7 @@ defmodule BathLARPWeb.V1.SessionController do
   end
 
   operation :delete,
+    operation_id: "deleteSession",
     summary: "Delete session",
     description: "Destroy a session on the BathLARP API and log out.",
     responses: %{

--- a/lib/bathlarp_web/router.ex
+++ b/lib/bathlarp_web/router.ex
@@ -23,7 +23,9 @@ defmodule BathLARPWeb.Router do
       resources "/confirmation", AccountConfirmationController, singleton: true, only: [:create]
     end
 
-    resources "/session", SessionController, singleton: true, only: [:create, :delete, :update]
+    resources "/session", SessionController, singleton: true, only: [:create, :delete]
+    # Specify the update path separately to avoid creation of PUT endpoint
+    patch "/session", SessionController, :update
   end
 
   scope "/v1", BathLARPWeb.V1, as: :api_v1 do

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -374,7 +374,7 @@ paths:
     post:
       callbacks: {}
       description: Create an account. Completing registration will require additional steps, detailed in the response.
-      operationId: BathLARPWeb.V1.AccountController.create
+      operationId: createAccount
       parameters: []
       requestBody:
         content:
@@ -409,7 +409,7 @@ paths:
     post:
       callbacks: {}
       description: Confirm that the e-mail address associated with a previously-created account has received a confirmation code.
-      operationId: BathLARPWeb.V1.AccountConfirmationController.create
+      operationId: createAccountConfirmation
       parameters:
         - description: Account ID
           example: df54c235-d8bf-431f-9525-f91484935252
@@ -451,7 +451,7 @@ paths:
     get:
       callbacks: {}
       description: List the pronoun sets currently supported by the BathLARP site.
-      operationId: BathLARPWeb.V1.PronounsController.index
+      operationId: listPronouns
       parameters: []
       responses:
         200:
@@ -473,7 +473,7 @@ paths:
     delete:
       callbacks: {}
       description: Destroy a session on the BathLARP API and log out.
-      operationId: BathLARPWeb.V1.SessionController.delete
+      operationId: deleteSession
       parameters: []
       responses:
         204:
@@ -490,7 +490,7 @@ paths:
     patch:
       callbacks: {}
       description: Refresh a session on the BathLARP API and obtain fresh access tokens.
-      operationId: BathLARPWeb.V1.SessionController.update (2)
+      operationId: updateSession
       parameters: []
       requestBody:
         content:
@@ -518,7 +518,7 @@ paths:
     post:
       callbacks: {}
       description: Create a session on the BathLARP API server and obtain access tokens.
-      operationId: BathLARPWeb.V1.SessionController.create
+      operationId: createSession
       parameters: []
       requestBody:
         content:
@@ -541,34 +541,6 @@ paths:
                 $ref: '#/components/schemas/JsonErrorResponse'
           description: Unprocessable Entity
       summary: Create session
-      tags:
-        - sessions
-    put:
-      callbacks: {}
-      description: Refresh a session on the BathLARP API and obtain fresh access tokens.
-      operationId: BathLARPWeb.V1.SessionController.update
-      parameters: []
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: '#/components/schemas/UpdateSessionRequest'
-        description: Session parameters
-        required: false
-      responses:
-        200:
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/UpdateSessionResponse'
-          description: Update session response
-        401:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsonErrorResponse'
-          description: Unprocessable Entity
-      summary: Update session
       tags:
         - sessions
 security: []


### PR DESCRIPTION
Fixes #10 .

Also tidies up the pipeline action for identifying version number changes and publishing the API client, and eliminates an undesired PUT version of the Update Session endpoint.