### PR TITLE
fix(auth) makes expiry req in schema

### DIFF
--- a/lib/bathlarp_web/controllers/v1/schemas/session.ex
+++ b/lib/bathlarp_web/controllers/v1/schemas/session.ex
@@ -116,7 +116,7 @@ defmodule BathLARPWeb.V1.Schemas.Session do
           format: :"date-time"
         }
       },
-      required: [:access_token, :renewal_token]
+      required: [:access_token, :renewal_token, :access_expiry]
     })
   end
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -312,6 +312,7 @@ components:
       required:
         - access_token
         - renewal_token
+        - access_expiry
       title: SessionAttributes
       type: object
       x-struct: Elixir.BathLARPWeb.V1.Schemas.Session.SessionAttributes


### PR DESCRIPTION
As per title - makes the expiry timestamp on session returns required.